### PR TITLE
[feat] 3주차 세미나 과제

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,9 +4,7 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="dca8429f-b831-434a-b92d-230d1f4e8c18" name="Changes" comment="[feat] Post 관련">
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-    </list>
+    <list default="true" id="dca8429f-b831-434a-b92d-230d1f4e8c18" name="Changes" comment="[chore] 불필요한 import 문 삭제" />
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -127,6 +125,7 @@
       <workItem from="1746112210080" duration="2374000" />
       <workItem from="1746195036894" duration="2429000" />
       <workItem from="1746368476788" duration="148000" />
+      <workItem from="1746371431234" duration="2947000" />
     </task>
     <task id="LOCAL-00001" summary="[refac] 객체 한 번씩만 생성하도록 수정">
       <option name="closed" value="true" />
@@ -168,7 +167,31 @@
       <option name="project" value="LOCAL" />
       <updated>1746113380506</updated>
     </task>
-    <option name="localTasksCounter" value="6" />
+    <task id="LOCAL-00006" summary="[refac] 네이밍 수정">
+      <option name="closed" value="true" />
+      <created>1746372698791</created>
+      <option name="number" value="00006" />
+      <option name="presentableId" value="LOCAL-00006" />
+      <option name="project" value="LOCAL" />
+      <updated>1746372698791</updated>
+    </task>
+    <task id="LOCAL-00007" summary="[refac] ResponseEntity 는 그대로 반환">
+      <option name="closed" value="true" />
+      <created>1746373585607</created>
+      <option name="number" value="00007" />
+      <option name="presentableId" value="LOCAL-00007" />
+      <option name="project" value="LOCAL" />
+      <updated>1746373585607</updated>
+    </task>
+    <task id="LOCAL-00008" summary="[chore] 불필요한 import 문 삭제">
+      <option name="closed" value="true" />
+      <created>1746373609495</created>
+      <option name="number" value="00008" />
+      <option name="presentableId" value="LOCAL-00008" />
+      <option name="project" value="LOCAL" />
+      <updated>1746373609495</updated>
+    </task>
+    <option name="localTasksCounter" value="9" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -191,7 +214,10 @@
     <MESSAGE value="[feat] User 도메인 구현" />
     <MESSAGE value="[feat] User 도메인 단 예외처리" />
     <MESSAGE value="[feat] Post 관련" />
-    <option name="LAST_COMMIT_MESSAGE" value="[feat] Post 관련" />
+    <MESSAGE value="[refac] 네이밍 수정" />
+    <MESSAGE value="[refac] ResponseEntity 는 그대로 반환" />
+    <MESSAGE value="[chore] 불필요한 import 문 삭제" />
+    <option name="LAST_COMMIT_MESSAGE" value="[chore] 불필요한 import 문 삭제" />
   </component>
   <component name="XSLT-Support.FileAssociations.UIState">
     <expand />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,46 +4,24 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="dca8429f-b831-434a-b92d-230d1f4e8c18" name="Changes" comment="[refac] Validator 책임 분리">
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/common/advice/GlobalExceptionHandler.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/common/advice/ResponseDtoAdvice.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/common/code/ApiCode.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/common/code/ErrorCode.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/common/code/GlobalErrorCode.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/common/code/SuccessCode.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/common/constants/PostTableConstants.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/common/response/ResponseDto.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/post/api/dto/request/PostCreateDto.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/post/api/dto/request/PostUpdateDto.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/post/api/dto/response/PostDetailsResponse.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/post/api/dto/response/PostListResponse.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/post/api/exception/PostApiErrorCode.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/post/api/exception/PostApiException.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/post/api/exception/PostConflictException.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/post/core/domain/PostEntity.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/post/core/exception/PostCoreErrorCode.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/post/core/exception/PostCoreException.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/post/core/exception/PostDuplicatedException.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/post/core/exception/PostNotFoundException.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.gitignore" beforeDir="false" afterPath="$PROJECT_DIR$/.gitignore" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/gradle.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/gradle.xml" afterDir="false" />
+    <list default="true" id="dca8429f-b831-434a-b92d-230d1f4e8c18" name="Changes" comment="[feat] mysql 의존성 추가">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/build.gradle" beforeDir="false" afterPath="$PROJECT_DIR$/build.gradle" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/settings.gradle" beforeDir="false" afterPath="$PROJECT_DIR$/settings.gradle" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/Main.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/Main.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/common/IdGenerator.java" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/post/api/config/PostConfig.java" beforeDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/common/advice/GlobalExceptionHandler.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/common/advice/GlobalExceptionHandler.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/common/constants/PostTableConstants.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/common/constants/PostTableConstants.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/post/api/controller/PostController.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/post/api/controller/PostController.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/post/api/dto/request/PostCreateDto.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/post/api/dto/request/PostCreateDto.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/post/api/dto/request/PostUpdateDto.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/post/api/dto/request/PostUpdateDto.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/post/api/dto/response/PostDetailsResponse.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/post/api/dto/response/PostDetailsResponse.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/post/api/dto/response/PostListResponse.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/post/api/dto/response/PostListResponse.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/post/api/exception/PostApiErrorCode.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/post/api/exception/PostApiErrorCode.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/post/api/service/PostService.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/post/api/service/PostService.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/post/api/utils/PostValidator.java" beforeDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/post/core/domain/Post.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/post/core/domain/Post.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/post/core/repository/PostBasicRepository.java" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/post/core/repository/PostFileRepository.java" beforeDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/post/core/domain/PostEntity.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/post/core/domain/PostEntity.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/post/core/repository/PostRepository.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/post/core/repository/PostRepository.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/post/core/service/PostRemover.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/post/core/service/PostRemover.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/post/core/service/PostRetriever.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/post/core/service/PostRetriever.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/post/core/service/PostSaver.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/post/core/service/PostSaver.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/post/core/service/PostUpdater.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/post/core/service/PostUpdater.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/post/core/service/PostRemover.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/post/core/facade/PostRemover.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/post/core/service/PostRetriever.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/post/core/facade/PostRetriever.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/post/core/service/PostSaver.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/post/core/facade/PostSaver.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/post/core/service/PostUpdater.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/post/core/facade/PostUpdater.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -77,9 +55,9 @@
       <list>
         <option value="Kotlin Class" />
         <option value="Interface" />
-        <option value="Class" />
         <option value="Record" />
         <option value="Enum" />
+        <option value="Class" />
       </list>
     </option>
   </component>
@@ -110,7 +88,7 @@
     &quot;RequestMappingsPanelWidth1&quot;: &quot;75&quot;,
     &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
     &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;seminar2&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;seminar3&quot;,
     &quot;kotlin-language-version-configured&quot;: &quot;true&quot;,
     &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
     &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
@@ -160,6 +138,9 @@
       <workItem from="1745341984337" duration="67000" />
       <workItem from="1745368099369" duration="4247000" />
       <workItem from="1745501009489" duration="2277000" />
+      <workItem from="1745946352142" duration="18480000" />
+      <workItem from="1746098415490" duration="118000" />
+      <workItem from="1746112210080" duration="469000" />
     </task>
     <task id="LOCAL-00001" summary="[refac] 객체 한 번씩만 생성하도록 수정">
       <option name="closed" value="true" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,24 +4,8 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="dca8429f-b831-434a-b92d-230d1f4e8c18" name="Changes" comment="[feat] mysql 의존성 추가">
+    <list default="true" id="dca8429f-b831-434a-b92d-230d1f4e8c18" name="Changes" comment="[feat] Post 관련">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/common/advice/GlobalExceptionHandler.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/common/advice/GlobalExceptionHandler.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/common/constants/PostTableConstants.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/common/constants/PostTableConstants.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/post/api/controller/PostController.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/post/api/controller/PostController.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/post/api/dto/request/PostCreateDto.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/post/api/dto/request/PostCreateDto.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/post/api/dto/request/PostUpdateDto.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/post/api/dto/request/PostUpdateDto.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/post/api/dto/response/PostDetailsResponse.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/post/api/dto/response/PostDetailsResponse.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/post/api/dto/response/PostListResponse.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/post/api/dto/response/PostListResponse.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/post/api/exception/PostApiErrorCode.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/post/api/exception/PostApiErrorCode.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/post/api/service/PostService.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/post/api/service/PostService.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/post/core/domain/Post.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/post/core/domain/Post.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/post/core/domain/PostEntity.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/post/core/domain/PostEntity.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/post/core/repository/PostRepository.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/post/core/repository/PostRepository.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/post/core/service/PostRemover.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/post/core/facade/PostRemover.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/post/core/service/PostRetriever.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/post/core/facade/PostRetriever.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/post/core/service/PostSaver.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/post/core/facade/PostSaver.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/post/core/service/PostUpdater.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/post/core/facade/PostUpdater.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -140,7 +124,9 @@
       <workItem from="1745501009489" duration="2277000" />
       <workItem from="1745946352142" duration="18480000" />
       <workItem from="1746098415490" duration="118000" />
-      <workItem from="1746112210080" duration="469000" />
+      <workItem from="1746112210080" duration="2374000" />
+      <workItem from="1746195036894" duration="2429000" />
+      <workItem from="1746368476788" duration="148000" />
     </task>
     <task id="LOCAL-00001" summary="[refac] 객체 한 번씩만 생성하도록 수정">
       <option name="closed" value="true" />
@@ -158,7 +144,31 @@
       <option name="project" value="LOCAL" />
       <updated>1745246080099</updated>
     </task>
-    <option name="localTasksCounter" value="3" />
+    <task id="LOCAL-00003" summary="[feat] User 도메인 구현">
+      <option name="closed" value="true" />
+      <created>1746113348165</created>
+      <option name="number" value="00003" />
+      <option name="presentableId" value="LOCAL-00003" />
+      <option name="project" value="LOCAL" />
+      <updated>1746113348165</updated>
+    </task>
+    <task id="LOCAL-00004" summary="[feat] User 도메인 단 예외처리">
+      <option name="closed" value="true" />
+      <created>1746113367140</created>
+      <option name="number" value="00004" />
+      <option name="presentableId" value="LOCAL-00004" />
+      <option name="project" value="LOCAL" />
+      <updated>1746113367140</updated>
+    </task>
+    <task id="LOCAL-00005" summary="[feat] Post 관련">
+      <option name="closed" value="true" />
+      <created>1746113380506</created>
+      <option name="number" value="00005" />
+      <option name="presentableId" value="LOCAL-00005" />
+      <option name="project" value="LOCAL" />
+      <updated>1746113380506</updated>
+    </task>
+    <option name="localTasksCounter" value="6" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -178,7 +188,10 @@
   <component name="VcsManagerConfiguration">
     <MESSAGE value="[refac] 객체 한 번씩만 생성하도록 수정" />
     <MESSAGE value="[refac] Validator 책임 분리" />
-    <option name="LAST_COMMIT_MESSAGE" value="[refac] Validator 책임 분리" />
+    <MESSAGE value="[feat] User 도메인 구현" />
+    <MESSAGE value="[feat] User 도메인 단 예외처리" />
+    <MESSAGE value="[feat] Post 관련" />
+    <option name="LAST_COMMIT_MESSAGE" value="[feat] Post 관련" />
   </component>
   <component name="XSLT-Support.FileAssociations.UIState">
     <expand />

--- a/build.gradle
+++ b/build.gradle
@@ -19,10 +19,14 @@ repositories {
 }
 
 dependencies {
+    // spring web
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    // database
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.h2database:h2'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    runtimeOnly 'com.mysql:mysql-connector-j'
 
     // Validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/main/java/org/sopt/common/advice/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/common/advice/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import org.sopt.common.code.GlobalErrorCode;
 import org.sopt.post.api.exception.PostApiException;
 import org.sopt.common.response.ResponseDto;
 import org.sopt.post.core.exception.PostCoreException;
+import org.sopt.user.core.exception.UserCoreException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -17,6 +18,13 @@ import java.util.Map;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler(UserCoreException.class)
+    public ResponseEntity<ResponseDto<Void>> handleUserCoreException(UserCoreException e) {
+        return ResponseEntity
+                .status(e.getStatus())
+                .body(ResponseDto.fail(e.getErrorCode()));
+    }
 
     @ExceptionHandler(PostApiException.class)
     public ResponseEntity<ResponseDto<Void>> handlePostApiException(PostApiException e) {

--- a/src/main/java/org/sopt/common/advice/ResponseWrappingAdvice.java
+++ b/src/main/java/org/sopt/common/advice/ResponseWrappingAdvice.java
@@ -15,7 +15,7 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
 @RestControllerAdvice(
         basePackages = "org.sopt"
 )
-public class ResponseDtoAdvice implements ResponseBodyAdvice<Object> {
+public class ResponseWrappingAdvice implements ResponseBodyAdvice<Object> {
     @Override
     public boolean supports(MethodParameter returnType, @NonNull Class converterType) {
         return !(returnType.getParameterType() == ResponseDto.class)

--- a/src/main/java/org/sopt/common/advice/ResponseWrappingAdvice.java
+++ b/src/main/java/org/sopt/common/advice/ResponseWrappingAdvice.java
@@ -1,7 +1,6 @@
 package org.sopt.common.advice;
 
 import lombok.NonNull;
-import org.sopt.common.code.ErrorCode;
 import org.sopt.common.response.ResponseDto;
 import org.sopt.common.code.SuccessCode;
 import org.springframework.core.MethodParameter;

--- a/src/main/java/org/sopt/common/advice/ResponseWrappingAdvice.java
+++ b/src/main/java/org/sopt/common/advice/ResponseWrappingAdvice.java
@@ -6,6 +6,7 @@ import org.sopt.common.response.ResponseDto;
 import org.sopt.common.code.SuccessCode;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
@@ -31,13 +32,10 @@ public class ResponseWrappingAdvice implements ResponseBodyAdvice<Object> {
             @NonNull ServerHttpRequest request,
             @NonNull ServerHttpResponse response
     ) {
-        if (body instanceof ResponseDto<?>) {
+        if (body instanceof ResponseEntity || body instanceof ResponseDto<?>) {
             return body;
         }
-        if (body instanceof ErrorCode)
-            return ResponseDto.fail((ErrorCode) body);
 
-        // 기본으로는 OK로 감싸고, 다른 것으로 처리하고 싶으면 Controller 에서 직접 감싸서 반환
         return ResponseDto.success(SuccessCode.OK, body);
     }
 }

--- a/src/main/java/org/sopt/common/constants/PostTableConstants.java
+++ b/src/main/java/org/sopt/common/constants/PostTableConstants.java
@@ -4,4 +4,7 @@ public class PostTableConstants {
     public final static String TABLE_POST = "post";
     public final static String COLUMN_ID = "id";
     public final static String COLUMN_TITLE = "title";
+    public final static String COLUMN_CONTENT = "content";
+    public final static String COLUMN_USER_ID = "user_id";
+    public final static String COLUMN_CREATED_AT = "created_at";
 }

--- a/src/main/java/org/sopt/common/constants/UserTableConstants.java
+++ b/src/main/java/org/sopt/common/constants/UserTableConstants.java
@@ -1,0 +1,7 @@
+package org.sopt.common.constants;
+
+public class UserTableConstants {
+    public final static String TABLE_USER = "user";
+    public final static String COLUMN_ID = "id";
+    public final static String NICKNAME = "nickname";
+}

--- a/src/main/java/org/sopt/post/api/controller/PostController.java
+++ b/src/main/java/org/sopt/post/api/controller/PostController.java
@@ -7,6 +7,8 @@ import org.sopt.post.api.dto.request.PostUpdateDto;
 import org.sopt.post.api.dto.response.PostListResponse;
 import org.sopt.post.api.service.PostService;
 import org.sopt.post.core.domain.Post;
+import org.sopt.user.api.service.UserService;
+import org.sopt.user.core.domain.User;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -16,28 +18,35 @@ import java.net.URI;
 @RequestMapping("/api/posts")
 public class PostController {
     private final PostService postService;
+    private final UserService userService;
 
-    public PostController(PostService postService) {
+    public PostController(PostService postService, UserService userService) {
         this.postService = postService;
+        this.userService = userService;
     }
 
-    @PostMapping("")
+    @PostMapping
     public ResponseEntity<Void> createPost(
+            @RequestHeader("Authorization") final long userId,
             @RequestBody @Valid final PostCreateDto postCreateDto
     ) {
-        int postId = postService.createPost(postCreateDto);
+        long postId = postService.createPost(userId, postCreateDto);
         return ResponseEntity.created(URI.create(Long.valueOf(postId).toString())).build();
     }
 
+    // 게시글 상세 조회
     @GetMapping("/{post-id}")
-    public ResponseEntity<PostDetailsResponse> getPost (
+    public ResponseEntity<PostDetailsResponse> getPostDetails (
+            @RequestHeader("Authorization") final long userId,
             @PathVariable(name = "post-id") final int postId
     ) {
-        final Post post = postService.getPostDetails(postId);
-        return ResponseEntity.ok(PostDetailsResponse.from(post));
+        final Post post = postService.getPostDetails(userId, postId);
+        final User user = userService.findById(post.getUserId());
+        return ResponseEntity.ok(PostDetailsResponse.from(post, user));
     }
 
-    @GetMapping("")
+    // 게시글 전체 조회
+    @GetMapping
     public ResponseEntity<PostListResponse> getPostList(
             @RequestParam(required = false) final String keyword
     ) {
@@ -46,18 +55,20 @@ public class PostController {
 
     @PutMapping("/{post-id}")
     public ResponseEntity<Void> updatePostTitle (
+            @RequestHeader("Authorization") final long userId,
             @PathVariable(name = "post-id") final int postId,
             @RequestBody @Valid final PostUpdateDto postUpdateDto
     ) {
-        postService.updatePostTitle(postId, postUpdateDto);
+        postService.updatePostTitle(userId, postId, postUpdateDto);
         return ResponseEntity.noContent().build();
     }
 
     @DeleteMapping("/{post-id}")
     public ResponseEntity<Void> deletePostById (
+            @RequestHeader("Authorization") final long userId,
             @PathVariable(name = "post-id") final int postId
     ) {
-        postService.deletePost(postId);
+        postService.deletePost(userId, postId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/org/sopt/post/api/dto/request/PostCreateDto.java
+++ b/src/main/java/org/sopt/post/api/dto/request/PostCreateDto.java
@@ -6,6 +6,8 @@ import jakarta.validation.constraints.Size;
 public record PostCreateDto(
         @NotBlank(message = "제목은 필수로 입력되어야 합니다.")
         @Size(max = 30, message = "제목은 30자 이하여야 합니다.")
-        String title
+        String title,
+        @Size(max = 1000, message = "게시글의 내용은 1000자 이하여야 합니다.")
+        String content
 ) {
 }

--- a/src/main/java/org/sopt/post/api/dto/request/PostUpdateDto.java
+++ b/src/main/java/org/sopt/post/api/dto/request/PostUpdateDto.java
@@ -6,6 +6,8 @@ import jakarta.validation.constraints.Size;
 public record PostUpdateDto(
         @NotBlank(message = "제목은 필수로 입력되어야 합니다.")
         @Size(max = 30, message = "제목은 30자 이하여야 합니다.")
-        String newTitle
+        String newTitle,
+        @Size(max = 1000, message = "게시글의 내용은 1000자 이하여야 합니다.")
+        String content
 ) {
 }

--- a/src/main/java/org/sopt/post/api/dto/response/PostDetailsResponse.java
+++ b/src/main/java/org/sopt/post/api/dto/response/PostDetailsResponse.java
@@ -1,14 +1,20 @@
 package org.sopt.post.api.dto.response;
 
 import org.sopt.post.core.domain.Post;
+import org.sopt.user.core.domain.User;
 
 public record PostDetailsResponse(
-        int id,
-        String title
+        long id,
+        String title,
+        String content,
+        String nickname
 ) {
-    public static PostDetailsResponse from(Post post) {
+    public static PostDetailsResponse from(Post post, User user) {
         return new PostDetailsResponse(
-                post.getId(), post.getTitle()
+                post.getId(),
+                post.getTitle(),
+                post.getContent(),
+                user.getNickname()
         );
     }
 }

--- a/src/main/java/org/sopt/post/api/dto/response/PostListResponse.java
+++ b/src/main/java/org/sopt/post/api/dto/response/PostListResponse.java
@@ -3,18 +3,32 @@ package org.sopt.post.api.dto.response;
 import org.sopt.post.core.domain.Post;
 
 import java.util.List;
+import java.util.Map;
 
 public record PostListResponse(
         List<PostDto> postsLists
 ) {
     public record PostDto(
-            int id,
-            String title
+            String title,
+            String nickname
     ) {
-        public static PostDto from(Post post) {
+        public static PostDto from(Post post, String nickname) {
             return new PostDto(
-                    post.getId(), post.getTitle()
+                    post.getTitle(),
+                    nickname
             );
         }
+    }
+    public static PostListResponse from(
+            List<Post> posts,
+            Map<Long, String> nicknameMap
+    ) {
+        final List<PostDto> postDtoList = posts.stream()
+                .map(post -> {
+                    String nickname = nicknameMap.getOrDefault(post.getUserId(), null);
+                    return PostDto.from(post, nickname);
+                }).toList();
+
+        return new PostListResponse(postDtoList);
     }
 }

--- a/src/main/java/org/sopt/post/api/exception/PostApiErrorCode.java
+++ b/src/main/java/org/sopt/post/api/exception/PostApiErrorCode.java
@@ -6,6 +6,9 @@ import org.springframework.http.HttpStatus;
 
 public enum PostApiErrorCode implements ErrorCode {
 
+    // 403
+    FORBIDDEN_POST(HttpStatus.FORBIDDEN, 40301, "해당 게시글에 접근할 수 있는 권한이 없습니다."),
+
     // 409
     CONFLICT_DUPLICATE_TITLE(HttpStatus.CONFLICT,40901, "중복되는 제목입니다."),
     CONFLICT_CREATE_LIMIT(HttpStatus.CONFLICT,40902, "작성 시간이 제한됩니다."),

--- a/src/main/java/org/sopt/post/api/exception/PostForBiddenException.java
+++ b/src/main/java/org/sopt/post/api/exception/PostForBiddenException.java
@@ -1,0 +1,15 @@
+package org.sopt.post.api.exception;
+
+import org.sopt.common.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class PostForBiddenException extends PostApiException{
+    public PostForBiddenException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.FORBIDDEN;
+    }
+}

--- a/src/main/java/org/sopt/post/api/service/PostService.java
+++ b/src/main/java/org/sopt/post/api/service/PostService.java
@@ -4,31 +4,35 @@ import org.sopt.post.api.dto.request.PostUpdateDto;
 import org.sopt.post.api.dto.response.PostListResponse;
 import org.sopt.post.api.exception.PostConflictException;
 import org.sopt.post.api.exception.PostApiErrorCode;
+import org.sopt.post.api.exception.PostForBiddenException;
 import org.sopt.post.core.domain.Post;
 import org.sopt.post.core.domain.PostEntity;
 import org.sopt.post.core.exception.PostDuplicatedException;
 import org.sopt.post.api.dto.request.PostCreateDto;
-import org.sopt.post.core.service.PostRemover;
-import org.sopt.post.core.service.PostRetriever;
-import org.sopt.post.core.service.PostSaver;
-import org.sopt.post.core.service.PostUpdater;
+import org.sopt.post.core.facade.PostRemover;
+import org.sopt.post.core.facade.PostRetriever;
+import org.sopt.post.core.facade.PostSaver;
+import org.sopt.post.core.facade.PostUpdater;
+import org.sopt.user.core.facade.UserFacade;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @Transactional(readOnly = true)
 public class PostService {
 
-    private LocalDateTime lastCreateTime = null;
+    private final UserFacade userFacade;
+//    private LocalDateTime lastCreateTime = null;
     private final PostRemover postRemover;
     private final PostRetriever postRetriever;
     private final PostUpdater postUpdater;
     private final PostSaver postSaver;
 
-    public PostService(PostRemover postRemover, PostRetriever postRetriever, PostUpdater postUpdater, PostSaver postSaver) {
+    public PostService(UserFacade userFacade, PostRemover postRemover, PostRetriever postRetriever, PostUpdater postUpdater, PostSaver postSaver) {
+        this.userFacade = userFacade;
         this.postRemover = postRemover;
         this.postRetriever = postRetriever;
         this.postUpdater = postUpdater;
@@ -36,57 +40,73 @@ public class PostService {
     }
 
     @Transactional
-    public int createPost(PostCreateDto postCreateDto) {
+    public long createPost(final long userId, PostCreateDto postCreateDto) {
+
+        userFacade.findUser(userId);
 
 //        if (!checkLatest3Minute()) {
 //            throw new PostConflictException(PostErrorCode.CONFLICT_CREATE_LIMIT);
 //        }
 
         final Post createPost;
-
         try {
-            createPost = postSaver.save(postCreateDto.title());
+            createPost = postSaver.save(userId, postCreateDto.title(), postCreateDto.content());
         } catch (PostDuplicatedException e) {
             throw new PostConflictException(PostApiErrorCode.CONFLICT_DUPLICATE_TITLE);
         }
-        lastCreateTime = LocalDateTime.now();
+//        lastCreateTime = LocalDateTime.now();
         return createPost.getId();
     }
 
-    public boolean checkLatest3Minute() {
-        if (lastCreateTime == null) return true;
+//    public boolean checkLatest3Minute() {
+//        if (lastCreateTime == null) return true;
+//
+//        LocalDateTime now = LocalDateTime.now();
+//        return java.time.Duration.between(lastCreateTime, now).getSeconds() >= 180;
+//    }
 
-        LocalDateTime now = LocalDateTime.now();
-        return java.time.Duration.between(lastCreateTime, now).getSeconds() >= 180;
-    }
-
-    public Post getPostDetails(final int postId) {
-        return postRetriever.findById(postId);
+    public Post getPostDetails(final long userId, final int postId) {
+        validatePostOwner(userId, postId);
+        return postRetriever.findById(userId, postId);
     }
 
     public PostListResponse getAllPosts(
             final String keyword
     ) {
-        List<PostListResponse.PostDto> posts = (keyword == null)
-                ? postRetriever.findAllPosts()
-                : postRetriever.findAllPostsByKeyword(keyword);
-            return new PostListResponse(posts);
+//        List<PostListResponse.PostDto> posts = (keyword == null)
+//                ? postRetriever.findAllPosts()
+//                : postRetriever.findAllPostsByKeyword(keyword);
+        List<Post> posts = postRetriever.findAllOrderByCreatedAtDesc();
+
+        Map<Long, String> nicknameMap = userFacade.findWriterNickname(posts);
+        return PostListResponse.from(posts, nicknameMap);
     }
 
     @Transactional
     public void updatePostTitle (
+            final long userId,
             final int postId,
             final PostUpdateDto postUpdateDto
     ) {
-        PostEntity postEntity = postRetriever.findEntityById(postId);
+        PostEntity postEntity = validatePostOwner(userId, postId);
         postUpdater.updatePost(postEntity, postUpdateDto);
     }
 
     @Transactional
     public void deletePost (
+            final long userId,
             final int postId
     ) {
-        PostEntity postEntity = postRetriever.findEntityById(postId);
+        PostEntity postEntity = validatePostOwner(userId, postId);
         postRemover.deletePost(postEntity);
+    }
+
+    private PostEntity validatePostOwner(final long userId, final int postId) {
+        userFacade.findUser(userId);
+        PostEntity postEntity = postRetriever.findEntityById(userId, postId);
+        if (postEntity.getUserId() != userId) {
+            throw new PostForBiddenException(PostApiErrorCode.FORBIDDEN_POST);
+        }
+        return postEntity;
     }
 }

--- a/src/main/java/org/sopt/post/core/domain/Post.java
+++ b/src/main/java/org/sopt/post/core/domain/Post.java
@@ -1,26 +1,50 @@
 package org.sopt.post.core.domain;
 
-public class Post {
-    private final int id;
-    private final String title;
 
-    public Post(int id, String title) {
+import java.time.LocalDateTime;
+
+public class Post {
+    private final long id;
+    private final long userId;
+    private final String title;
+    private final String content;
+    private final LocalDateTime createdAt;
+
+    public Post(long id, long userId, String title, String content, LocalDateTime createdAt) {
         this.id = id;
+        this.userId = userId;
         this.title = title;
+        this.content = content;
+        this.createdAt = createdAt;
     }
 
-    public int getId(){
+    public long getId(){
         return id;
+    }
+
+    public long getUserId(){
+        return userId;
     }
 
     public String getTitle() {
         return title;
     }
 
+    public String getContent(){
+        return content;
+    }
+
+    public LocalDateTime getCreatedAt(){
+        return createdAt;
+    }
+
     public static Post fromEntity(final PostEntity postEntity) {
         return new Post(
                 postEntity.getId(),
-                postEntity.getTitle()
+                postEntity.getUserId(),
+                postEntity.getTitle(),
+                postEntity.getContent(),
+                postEntity.getCreatedAt()
         );
     }
 }

--- a/src/main/java/org/sopt/post/core/domain/PostEntity.java
+++ b/src/main/java/org/sopt/post/core/domain/PostEntity.java
@@ -19,10 +19,10 @@ public class PostEntity {
     @Id
     @Column(name = COLUMN_ID)
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private long id;
+    private Long id;
 
     @Column(name = COLUMN_USER_ID)
-    private long userId;
+    private Long userId;
 
     @Column(name = COLUMN_TITLE, nullable = false)
     private String title;

--- a/src/main/java/org/sopt/post/core/domain/PostEntity.java
+++ b/src/main/java/org/sopt/post/core/domain/PostEntity.java
@@ -3,6 +3,10 @@ package org.sopt.post.core.domain;
 import jakarta.persistence.*;
 import org.sopt.common.constants.PostTableConstants;
 
+import java.time.LocalDateTime;
+
+import static org.sopt.common.constants.PostTableConstants.*;
+
 @Entity
 @Table(
         name = PostTableConstants.TABLE_POST,
@@ -13,30 +17,61 @@ import org.sopt.common.constants.PostTableConstants;
 public class PostEntity {
 
     @Id
-    @Column(name = PostTableConstants.COLUMN_ID)
+    @Column(name = COLUMN_ID)
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private int id;
+    private long id;
 
-    @Column(name=PostTableConstants.COLUMN_TITLE)
+    @Column(name = COLUMN_USER_ID)
+    private long userId;
+
+    @Column(name = COLUMN_TITLE, nullable = false)
     private String title;
+
+    @Column(name = COLUMN_CONTENT)
+    private String content;
+
+    @Column(name = COLUMN_CREATED_AT, nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+    }
 
     protected PostEntity(){
 
     }
 
-    public PostEntity(String title) {
+    public PostEntity(long userId, String title, String content) {
+        this.userId = userId;
         this.title = title;
+        this.content = content;
     }
 
     public void updateTitle(String newTitle) {
         this.title = newTitle;
     }
 
-    public int getId() {
+    public void updateContent(String content) {
+        this.content = content;
+    }
+
+    public long getId() {
         return this.id;
+    }
+    public long getUserId(){
+        return userId;
     }
 
     public String getTitle() {
         return this.title;
+    }
+
+    public String getContent(){
+        return this.content;
+    }
+
+    public LocalDateTime getCreatedAt(){
+        return createdAt;
     }
 }

--- a/src/main/java/org/sopt/post/core/facade/PostRemover.java
+++ b/src/main/java/org/sopt/post/core/facade/PostRemover.java
@@ -1,4 +1,4 @@
-package org.sopt.post.core.service;
+package org.sopt.post.core.facade;
 
 import org.sopt.post.core.domain.PostEntity;
 import org.sopt.post.core.repository.PostRepository;

--- a/src/main/java/org/sopt/post/core/facade/PostRetriever.java
+++ b/src/main/java/org/sopt/post/core/facade/PostRetriever.java
@@ -1,4 +1,4 @@
-package org.sopt.post.core.service;
+package org.sopt.post.core.facade;
 
 import org.sopt.post.api.dto.response.PostListResponse;
 import org.sopt.post.core.domain.Post;
@@ -18,28 +18,30 @@ public class PostRetriever {
         this.postRepository = postRepository;
     }
 
-    public Post findById(final int postId) {
-        final PostEntity postEntity = postRepository.findById(postId)
+    public Post findById(final long userId, final long postId) {
+        final PostEntity postEntity = postRepository.findByUserIdAndId(userId, postId)
                 .orElseThrow(()-> new PostNotFoundException(PostCoreErrorCode.NOT_FOUND_POST));
         return Post.fromEntity(postEntity);
     }
 
-    public PostEntity findEntityById(final int postId) {
-        return postRepository.findById(postId)
+    public PostEntity findEntityById(final long userId, final long postId) {
+        return postRepository.findByUserIdAndId(userId, postId)
                 .orElseThrow(()-> new PostNotFoundException(PostCoreErrorCode.NOT_FOUND_POST));
     }
 
-    public List<PostListResponse.PostDto> findAllPosts(){
-        return postRepository.findAll().stream()
+    public List<Post> findAllOrderByCreatedAtDesc() {
+        return postRepository.findAllOrderByCreatedAtDesc().stream()
                 .map(Post::fromEntity)
-                .map(PostListResponse.PostDto::from)
                 .toList();
     }
 
-    public List<PostListResponse.PostDto> findAllPostsByKeyword(final String keyword) {
-        return postRepository.findByKeyword(keyword).stream()
-                .map(Post::fromEntity)
-                .map(PostListResponse.PostDto::from)
-                .toList();
-    }
+    /*
+     아직 미구현
+     */
+//    public List<PostListResponse.PostDto> findAllPostsByKeyword(final String keyword) {
+//        return postRepository.findByKeyword(keyword).stream()
+//                .map(Post::fromEntity)
+//                .map(PostListResponse.PostDto::from)
+//                .toList();
+//    }
 }

--- a/src/main/java/org/sopt/post/core/facade/PostSaver.java
+++ b/src/main/java/org/sopt/post/core/facade/PostSaver.java
@@ -1,4 +1,4 @@
-package org.sopt.post.core.service;
+package org.sopt.post.core.facade;
 
 import org.sopt.post.core.domain.Post;
 import org.sopt.post.core.domain.PostEntity;
@@ -18,9 +18,9 @@ public class PostSaver {
     }
 
     @Transactional
-    public Post save(final String title) {
+    public Post save(final long userId, final String title, final String content) {
         try {
-            final PostEntity postEntity = postRepository.save(new PostEntity(title));
+            final PostEntity postEntity = postRepository.save(new PostEntity(userId, title, content));
             return Post.fromEntity(postEntity);
         } catch (DataIntegrityViolationException e) {
             throw new PostDuplicatedException(PostCoreErrorCode.DUPLICATED_POST);

--- a/src/main/java/org/sopt/post/core/facade/PostUpdater.java
+++ b/src/main/java/org/sopt/post/core/facade/PostUpdater.java
@@ -1,4 +1,4 @@
-package org.sopt.post.core.service;
+package org.sopt.post.core.facade;
 
 import org.sopt.post.api.dto.request.PostUpdateDto;
 import org.sopt.post.core.domain.PostEntity;

--- a/src/main/java/org/sopt/post/core/repository/PostRepository.java
+++ b/src/main/java/org/sopt/post/core/repository/PostRepository.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<PostEntity, Integer> {
-    Optional<PostEntity> findById(int diaryId);
+    Optional<PostEntity> findByUserIdAndId(Long userId, Long postId);
     List<PostEntity> findAll();
 
     @Query("""
@@ -17,4 +17,11 @@ public interface PostRepository extends JpaRepository<PostEntity, Integer> {
         WHERE p.title LIKE CONCAT('%', :keyword, '%')
     """)
     List<PostEntity> findByKeyword(String keyword);
+
+    @Query("""
+    SELECT p
+    FROM PostEntity p
+    ORDER BY p.createdAt DESC
+""")
+    List<PostEntity> findAllOrderByCreatedAtDesc();
 }

--- a/src/main/java/org/sopt/user/api/controller/UserController.java
+++ b/src/main/java/org/sopt/user/api/controller/UserController.java
@@ -1,0 +1,31 @@
+package org.sopt.user.api.controller;
+
+import jakarta.validation.Valid;
+import org.sopt.user.api.service.UserService;
+import org.sopt.user.api.dto.UserSignupDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+
+@RestController
+@RequestMapping("/auth")
+public class UserController {
+
+    private final UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @PostMapping("/users/signup")
+    public ResponseEntity<Void> signup(
+            @RequestBody @Valid final UserSignupDto userSignupDto
+    ){
+        long userId = userService.signup(userSignupDto);
+        return ResponseEntity.created(URI.create(Long.valueOf(userId).toString())).build();
+    }
+}

--- a/src/main/java/org/sopt/user/api/dto/UserSignupDto.java
+++ b/src/main/java/org/sopt/user/api/dto/UserSignupDto.java
@@ -1,0 +1,11 @@
+package org.sopt.user.api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UserSignupDto(
+        @NotBlank(message = "닉네임은 필수로 입력되어야 합니다")
+        @Size(max = 30, message = "닉네임은 30자 이하여야 합니다.")
+        String nickname
+) {
+}

--- a/src/main/java/org/sopt/user/api/service/UserService.java
+++ b/src/main/java/org/sopt/user/api/service/UserService.java
@@ -1,0 +1,27 @@
+package org.sopt.user.api.service;
+
+import org.sopt.user.api.dto.UserSignupDto;
+import org.sopt.user.core.domain.User;
+import org.sopt.user.core.facade.UserRetriever;
+import org.sopt.user.core.facade.UserSaver;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserService {
+
+    private final UserSaver userSaver;
+    private final UserRetriever userRetriever;
+
+    public UserService(UserSaver userSaver, UserRetriever userRetriever) {
+        this.userSaver = userSaver;
+        this.userRetriever = userRetriever;
+    }
+
+    public long signup(UserSignupDto userSignupDto){
+        return userSaver.save(userSignupDto.nickname()).getId();
+    }
+
+    public User findById(final long userId) {
+        return userRetriever.findById(userId);
+    }
+}

--- a/src/main/java/org/sopt/user/core/domain/User.java
+++ b/src/main/java/org/sopt/user/core/domain/User.java
@@ -1,0 +1,26 @@
+package org.sopt.user.core.domain;
+
+public class User {
+    private final Long id;
+    private final String nickname;
+
+    public User(Long id, String nickname) {
+        this.id = id;
+        this.nickname = nickname;
+    }
+
+    public Long getId(){
+        return id;
+    }
+
+    public String getNickname(){
+        return nickname;
+    }
+
+    public static User fromEntity(final UserEntity userEntity) {
+        return new User(
+                userEntity.getId(),
+                userEntity.getNickname()
+        );
+    }
+}

--- a/src/main/java/org/sopt/user/core/domain/UserEntity.java
+++ b/src/main/java/org/sopt/user/core/domain/UserEntity.java
@@ -1,0 +1,35 @@
+package org.sopt.user.core.domain;
+
+import jakarta.persistence.*;
+import org.sopt.common.constants.UserTableConstants;
+
+import static org.sopt.common.constants.UserTableConstants.*;
+
+@Entity
+@Table(name = UserTableConstants.TABLE_USER)
+public class UserEntity {
+
+    @Id
+    @Column(name = COLUMN_ID)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = NICKNAME)
+    private String nickname;
+
+    protected UserEntity(){
+
+    }
+
+    public UserEntity(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public Long getId(){
+        return this.id;
+    }
+
+    public String getNickname(){
+        return this.nickname;
+    }
+}

--- a/src/main/java/org/sopt/user/core/exception/UserCoreErrorCode.java
+++ b/src/main/java/org/sopt/user/core/exception/UserCoreErrorCode.java
@@ -1,0 +1,36 @@
+package org.sopt.user.core.exception;
+
+import org.sopt.common.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum
+UserCoreErrorCode implements ErrorCode {
+    // 404
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, 40410, "존재하지 않는 사용자입니다."),
+    ;
+
+    public final HttpStatus httpStatus;
+    private final int code;
+    private final String message;
+
+    UserCoreErrorCode(HttpStatus httpStatus, int code, String message) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus(){
+        return httpStatus;
+    }
+
+    @Override
+    public int getCode(){
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/org/sopt/user/core/exception/UserCoreException.java
+++ b/src/main/java/org/sopt/user/core/exception/UserCoreException.java
@@ -1,0 +1,20 @@
+package org.sopt.user.core.exception;
+
+import org.sopt.common.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public abstract class UserCoreException extends RuntimeException{
+
+    private final ErrorCode errorCode;
+
+    protected UserCoreException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode(){
+        return errorCode;
+    }
+
+    public abstract HttpStatus getStatus();
+}

--- a/src/main/java/org/sopt/user/core/exception/UserNotFoundException.java
+++ b/src/main/java/org/sopt/user/core/exception/UserNotFoundException.java
@@ -1,0 +1,15 @@
+package org.sopt.user.core.exception;
+
+import org.sopt.common.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class UserNotFoundException extends UserCoreException{
+    public UserNotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.NOT_FOUND;
+    }
+}

--- a/src/main/java/org/sopt/user/core/facade/UserFacade.java
+++ b/src/main/java/org/sopt/user/core/facade/UserFacade.java
@@ -1,0 +1,26 @@
+package org.sopt.user.core.facade;
+
+import org.sopt.post.core.domain.Post;
+import org.sopt.user.core.domain.User;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class UserFacade {
+    private final UserRetriever userRetriever;
+
+    public UserFacade(UserRetriever userRetriever) {
+        this.userRetriever = userRetriever;
+    }
+
+    public User findUser(final long userId) {
+        return userRetriever.findById(userId);
+    }
+
+    public Map<Long, String> findWriterNickname(final List<Post> postList) {
+        final List<Long> userIdList = postList.stream().map(Post::getUserId).toList();
+        return userRetriever.findNicknameMap(userIdList);
+    }
+}

--- a/src/main/java/org/sopt/user/core/facade/UserRetriever.java
+++ b/src/main/java/org/sopt/user/core/facade/UserRetriever.java
@@ -1,0 +1,42 @@
+package org.sopt.user.core.facade;
+
+import org.sopt.user.core.domain.User;
+import org.sopt.user.core.domain.UserEntity;
+import org.sopt.user.core.exception.UserCoreErrorCode;
+import org.sopt.user.core.exception.UserNotFoundException;
+import org.sopt.user.core.repository.UserRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+@Transactional(readOnly = true)
+public class UserRetriever {
+
+    private final UserRepository userRepository;
+
+    public UserRetriever(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    public User findById(final long userId) {
+        final UserEntity userEntity = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(UserCoreErrorCode.USER_NOT_FOUND));
+        return User.fromEntity(userEntity);
+    }
+
+    public Map<Long, String> findNicknameMap(final List<Long> userIdList) {
+        final List<UserEntity> userList = userRepository.findAllById(userIdList);
+
+        return userList.stream()
+                .collect(
+                        Collectors.toMap(
+                                UserEntity::getId,
+                                UserEntity::getNickname
+                        )
+                );
+    }
+}

--- a/src/main/java/org/sopt/user/core/facade/UserSaver.java
+++ b/src/main/java/org/sopt/user/core/facade/UserSaver.java
@@ -1,0 +1,23 @@
+package org.sopt.user.core.facade;
+
+import org.sopt.user.core.domain.User;
+import org.sopt.user.core.domain.UserEntity;
+import org.sopt.user.core.repository.UserRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class UserSaver {
+
+    private final UserRepository userRepository;
+
+    public UserSaver(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Transactional
+    public User save(final String nickname) {
+        final UserEntity userEntity = userRepository.save(new UserEntity(nickname));
+        return User.fromEntity(userEntity);
+    }
+}

--- a/src/main/java/org/sopt/user/core/repository/UserRepository.java
+++ b/src/main/java/org/sopt/user/core/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package org.sopt.user.core.repository;
+
+import org.sopt.user.core.domain.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<UserEntity, Long> {
+    Optional<UserEntity> findById(Long id);
+}


### PR DESCRIPTION
PR 설명은 조금 간략하게..

## ⭐ TODO

**[필수 과제]**

- [x]  서비스에 유저를 추가해주세요.
- [x]  게시글은 기본적으로 제목과 내용을 가지고 있으면 좋겠어요. 
- 단, 제목과 내용은 비어 있으면 안 돼요.
- [x]  회원가입 기능을 추가해주세요.
- [x]  다음과 같은 API를 기본적으로 만들어주세요.
- 게시글 생성 API
- 게시글 전체 조회 API (최신 순으로 조회 / 제목과 게시글 작성자만 보일 수 있도록 해주세요.)
- 게시글 상세 조회 API (제목과 내용, 게시글 작성자가 모두 보이도록 해주세요.)
- 게시글 수정 API 
- 게시글 삭제 API

**[선택 과제]**

- [x]  다음과 같은 제약 조건을 추가해주세요.
- 게시글의 제목은 30자를 넘지 않게 해주세요.
- 게시글의 내용은 1000자를 넘지 않게 해주세요.
- 유저의 이름(닉네임)은 10자를 넘지 않게 해주세요.
- [x]  다음과 같은 제약 조건을 추가해주세요.
- 게시글의 제목은 중복되지 않게 해주세요.
- 전체 게시글 목록에서 같은 제목을 가진 게시글이 없어야 합니다.
- [ ]  검색 기능을 추가해주세요. 
- 사용자는 `게시글 제목` 혹은 `작성자` 를 기준으로 검색할 수 있습니다. (둘 다 구현해주세요.)
- 검색의 기준은 `검색어를 포함하고 있냐` 를 기준으로 해주시면 됩니다.
- [ ]  게시글에 태그를 지정할 수 있으면 좋겠어요.
- 아티클에도 종류가 정말 많잖아요.
- 이게 어떤 아티클인지에 대해 태그를 지정할 수 있으면 좋겠어요.
- 태그는 고정적으로 `백엔드` `데이터베이스` `인프라` 이렇게 3개 중 `하나만` 고르는 걸로 할게요.
- 태그 기능을 추가하신다면, 태그를 기반으로 검색하는 기능도 추가해주세요.

---

## ✅ UserFacade

```java
@Component
public class UserFacade {
    private final UserRetriever userRetriever;

    public UserFacade(UserRetriever userRetriever) {
        this.userRetriever = userRetriever;
    }

    public User findUser(final long userId) {
        return userRetriever.findById(userId);
    }

    public Map<Long, String> findWriterNickname(final List<Post> postList) {
        final List<Long> userIdList = postList.stream().map(Post::getUserId).toList();
        return userRetriever.findNicknameMap(userIdList);
    }
}
```

외부 도메인에서(ex. Post) 유저 정보를 조회할 때, 직접 User 도메인에 접근하지 않고 인터페이스를 통해 조회할 수 있도록 도와줌. → 도메인 간 의존성 낮추기

- `findWriterNickname()` : PostService 에서 유저 도메인의 영역에 있는 작성자의 닉네임을 조회해야할 때 사용
- `findUser()` : PostService 에서 유저 도메인의 영역에 있는 특정 유저의 상세 정보를 가져오기 위해 사용

---

## ✅ 연관 관계 매핑 사용에 대한 고민..
(매핑 안쓰는거 궁금해서 한 번 해보았음ㅎㅎ)
- 연관 관계를 어노테이션으로 직접 맺지 않고, PostEntity 가 부모인 UserEntity의 id 를 외래키처럼 직접 가지고 있도록 설계
- 분명한 장점이 있으나 개발자가 작성해야 하는 코드의 라인 수가 많아짐.. 명확한 트레이드 오프 ㅠㅠ
    - post.getUser().getId() 같이 편하게 접근하는거 불가능
    - cascade 삭제 등 불가능

```java
public class PostEntity {

    @Id
    @Column(name = COLUMN_ID)
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    private long id;

    @Column(name = COLUMN_USER_ID)
    **private long userId;**
    
    ...
    
}
```

---

## ✅ 예외 처리

### 📌 어떤 상황에 어떤 예외가 터질까?

### User

- 존재하지 않는 사용자를 RequestHeader 에 넣어서 요청을 보낼 경우 → 404

### Post

- 중복되는 제목의 게시글을 작성하려고 시도할 경우 → 409
- 유저는 있으나, 해당 유저가 자신이 작성하지 않은 게시글에 대한 접근을 시도할 경우 → 403
- 존재하지 않는 게시글에 대한 작업을 요청할 경우 → 404

### Global

- @Valid 에서 예외가 발생한 경우
- 잘못된 HTTP 메서드로 요청을 보냈을 경우
- 요청한 API 엔드포인트가 존재하지 않는 경우
- 그 외 알 수 없는 서버 내부 오류

### 📌 내 과제에서의 예외 처리 구조

![image](https://github.com/user-attachments/assets/a41c5d1f-650c-4340-9c26-53d9086b9cb4)

- API 단 예외와 도메인 단의 예외 처리를 분리 → 후에 GlobalExceptionHandler 에서 잡아서 처리
    - PostApiException, PostApiErrorCode → 컨트롤러, 유효성 검증 등 api 단 예외
    - PostCoreException, PostCoreErrorCode → 도메인 단 예외
- GlobalExceptionHandler 에는 구체적인 예외 클래스들을 모두 잡는게 아니라, 도메인 별로 core 와 api 예외 클래스만 잡아서 처리하는 구조

---

## ✅ (+) `@ReqeustHeader` 살펴보기

> 개선해야 하지만 아직 시간이 없어 리팩 못함..!
> 

### 📌 `@RequestHeader` 클래스 내부를 살펴보면..

![image](https://github.com/user-attachments/assets/6ffa42c5-2b7e-4ab0-9535-f441fad864bd)

required() 가 defult true 인 것을 확인할 수 있다. 

따라서 아래처럼 Authorization 의 값이 없으면 예외를 발생시키는 것을 확인할 수 있다.

![image](https://github.com/user-attachments/assets/3e20ac35-6c0e-44a4-b10a-0f7dffc57425)

그래서 userId 는 long 으로 보장이 될 것이므로, Long 대신 long 을 사용함.

```java
    @PostMapping
    public ResponseEntity<Void> createPost(
            **@RequestHeader("Authorization") final long userId,**
            @RequestBody @Valid final PostCreateDto postCreateDto
    ) {
        long postId = postService.createPost(userId, postCreateDto);
        return ResponseEntity.created(URI.create(Long.valueOf(postId).toString())).build();
    }
```

### 📌 Authorization 헤더의 value 가 String 이 들어온다면..?

⇒ 또한 예외 발생!

그래서 `@RequsetHeader` 를 사용하려면 앞서 발생한 여러 예외들에 대한 처리를 잘 해줄 필요가 있음..

![image](https://github.com/user-attachments/assets/bbabc83b-e77c-420d-9afb-5f3d9cb9f077)

### 📌 해결책

- ArgumentResolver 로 커스텀 어노테이션 만들어서 앞서 예외들 처리해주기!
- Spring Security 사용한다면 @AuthenticationPrincipal 사용도 고려해볼 수 있겠다.

---

## ✅ 키워드 과제

### 📌 ERD는 무엇이고, 어떻게 작성하나요? (ERD Cloud 같은 ERD 작성 툴 사용해보기)
ERD란 ..
- 어떤 테이블(=엔티티) 들이 있는지
- 각 테이블에 어떤 컬럼(속성) 이 있는지
- 테이블 간 관계는 어떻게 되어 있는지 (1:1, 1:N, N:M)
![image](https://github.com/user-attachments/assets/10e7cb9b-2e4e-4dbb-ae10-f38364fbd856)

<h3>📌 게시글을 100개 작성한 유저가 회원 탈퇴를 해본다고 할게요. 남는 게시글은 어떻게 처리해야 될까요 ?</h3>
<ul>
<li>
<p><strong>연관관계 설정이 없다면..</strong></p>
<ul>
<li>User가 삭제되어도 Post는 남게 됨.</li>
<li>FK 제약 조건이 걸려 있다면, User 삭제 시, Post가 존재하므로 오류 발생!</li>
</ul>
</li>
<li>
<p><strong><code>@ManyToOne</code>, <code>@OneToMany</code> 어노테이션 사용한다면..</strong></p>
<ul>
<li>cascade 설정을 통해서 User 삭제 시 Post 도 삭제되도록 할 수 있다.</li>
</ul>
<pre><code class="language-java">@OneToMany(mappedBy = &quot;user&quot;, cascade = CascadeType.REMOVE, orphanRemoval = true)
private List&lt;PostEntity&gt; posts = new ArrayList&lt;&gt;();
</code></pre>

CascadeType | 설명
-- | --
ALL | 모든 Cascade를 적용한다.
PERSIST | 엔티티를 영속화할 때, 연관된 하위 엔티티도 함께 유지한다.
MERGE | 엔티티 상태를 병합(Merge)할 때, 연관된 하위 엔티티도 모두 병합한다.
REMOVE | 엔티티를 제거할 때, 연관된 하위 엔티티도 모두 제거한다.
DETACH | 영속성 컨텍스트에서 엔티티를 제거한다. 부모 엔티티를 detach() 수행하면, 연관 하위 엔티티도 detach()상태가 되어 변경 사항을 반영하지 않는다.
REFRESH | 상위 엔티티를 새로고침(Refresh)할 때, 연관된 하위 엔티티도 모두 새로고침한다.


<ul>
<li>각 서비스의 정책에 따라서 Post는 남기되, User 의 정보만 null 로 처리할 수도 있겠다. (ex. 회원 탈퇴 시 ‘알 수 없는 사용자’로 처리)</li>
</ul>
</li>
<li>
<p><strong><code>fetch</code> 옵션</strong> :  모든 연관관계는 지연로딩으로 설정하자!</p>
<ul>
<li><strong><code>@**XTo**One</code></strong> 은 디폴트가 <code>EAGER</code> 이기 때문에, 모두 **<code>fetch = FetchType.LAZY</code>**로 직접 설정해 주어야 한다.</li>
<li>EAGER 은 연관된 엔티티를 즉시 로드하므로, 불필요한 데이터베이스 조회로 성능 저하를 유발할 수 있다. 따라서 연관관계를 지연 로딩(<code>FetchType.LAZY</code>)으로 설정하면, 실제로 해당 연관 엔티티가 필요할 때만 데이터베이스에서 조회한다.</li>
<li><code>@XToMany</code> 는 디폴트가 LAZY이므로 상관 없다.</li>
</ul>
</li>
</ul>
<!-- notionvc: 2e5abe86-49fe-4838-b3ac-e1d3164d450a -->